### PR TITLE
Persist and restore Tabulator state around advanced search

### DIFF
--- a/nginx/html/assets/js/bus_adv_abm_op.js
+++ b/nginx/html/assets/js/bus_adv_abm_op.js
@@ -7,6 +7,9 @@ import { mostrarMensaje, mostrarMensajeConCancelar,
         from './utilidades_abm_op.js';
         
 export function mostrarBusquedaAvanzada() {
+    // Guardar el estado actual del Tabulator antes de aplicar filtros avanzados
+    almacenarEstadoTablaOriginal();
+
     document.getElementById("formBusquedaAvanzada").reset();
     limpiarTodosLosErrores();
     document.getElementById("modalBusquedaAvanzada").style.display = "flex";


### PR DESCRIPTION
## Summary
- Save Tabulator's URL, filters, sorters, pagination and data count before opening advanced search
- Restore original data, page and ordering when removing filters and report restored record count

## Testing
- `node --check nginx/html/assets/js/bus_adv_abm_op.js`
- `node --check nginx/html/assets/js/utilidades_abm_op.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ff7142f088327a7fcc9436454f394